### PR TITLE
Implement save-as feature

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -545,7 +545,9 @@ char *editorPrompt(char *prompt) {
         editorRefreshScreen();
 
         int c = editorReadKey();
-        if (c == '\x1b') {
+        if (c == DEL_KEY || c == CTRL_KEY('h') || c == BACKSPACE) {
+            if (buflen != 0) buf[--buflen] = '\0';
+        } else if (c == '\x1b') {
             editorSetStatusMessage("");
             free(buf);
             return NULL;

--- a/kilo.c
+++ b/kilo.c
@@ -367,7 +367,11 @@ void editorOpen(char *filename) {
 
 void editorSave() {
     if (E.filename == NULL) {
-        E.filename = editorPrompt("Save as: %s");
+        E.filename = editorPrompt("Save as: %s (ESC to cancel)");
+        if (E.filename == NULL) {
+            editorSetStatusMessage("Save aborted");
+            return;
+        }
     }
 
     int len;

--- a/kilo.c
+++ b/kilo.c
@@ -69,6 +69,7 @@ struct editorConfig E;
 
 void editorSetStatusMessage(const char *fmt, ...);
 void editorRefreshScreen();
+char *editorPrompt(char *prompt);
 
 struct termios orig_termios;
 
@@ -365,7 +366,9 @@ void editorOpen(char *filename) {
 }
 
 void editorSave() {
-    if (E.filename == NULL) return;
+    if (E.filename == NULL) {
+        E.filename = editorPrompt("Save as: %s");
+    }
 
     int len;
     char *buf = editorRowsToString(&len);

--- a/kilo.c
+++ b/kilo.c
@@ -541,7 +541,11 @@ char *editorPrompt(char *prompt) {
         editorRefreshScreen();
 
         int c = editorReadKey();
-        if (c == '\r') {
+        if (c == '\x1b') {
+            editorSetStatusMessage("");
+            free(buf);
+            return NULL;
+        } else if (c == '\r') {
             if (buflen != 0) {
                 editorSetStatusMessage("");
                 return buf;

--- a/kilo.c
+++ b/kilo.c
@@ -68,6 +68,7 @@ struct editorConfig E;
 /*** prototypes ***/
 
 void editorSetStatusMessage(const char *fmt, ...);
+void editorRefreshScreen();
 
 struct termios orig_termios;
 
@@ -525,6 +526,33 @@ void editorSetStatusMessage(const char *fmt, ...) {
 }
 
 /*** input ***/
+
+char *editorPrompt(char *prompt) {
+    size_t bufsize = 128;
+    char *buf = malloc(bufsize);
+    size_t buflen = 0;
+    buf[0] = '\0';
+
+    while (1) {
+        editorSetStatusMessage(prompt, buf);
+        editorRefreshScreen();
+
+        int c = editorReadKey();
+        if (c == '\r') {
+            if (buflen != 0) {
+                editorSetStatusMessage("");
+                return buf;
+            }
+        } else if (!iscntrl(c) && c < 128) {
+            if (buflen == bufsize - 1) {
+                bufsize *= 2;
+                buf = realloc(buf, bufsize);
+            }
+            buf[buflen++] = c;
+            buf[buflen] = '\0';
+        }
+    }
+}
 
 void editorMoveCursor(int key) {
     erow *row = (E.cy >= E.numrows) ? NULL : &E.row[E.cy];


### PR DESCRIPTION
We present a `save-as` prompt to save files with a user-specified file name inside the editor. This closes #15.
Signed-off-by: Delwin Perera <perera@mm.tu-darmstadt.de>